### PR TITLE
feat: add automatic detection of cpu architecture

### DIFF
--- a/docker/dockerfile.df
+++ b/docker/dockerfile.df
@@ -6,7 +6,8 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 
 # Pandoc binary as .deb -- see https://github.com/jgm/pandoc/releases/latest
-ARG PANDOCDEB=https://github.com/jgm/pandoc/releases/download/2.11.4/pandoc-2.11.4-1-amd64.deb
+ARG TARGETARCH
+ARG PANDOCDEB=https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-1-${TARGETARCH}.deb
 
 # Install everything
 RUN apt-get update                                                          \


### PR DESCRIPTION
Hey, I have added a docker argument to automatically pull the right version of `pandoc`, removing the need to manually change the argument when switching between multiple devices.

I've tested this on my macOS ARM machine, I could **NOT** verify on AMD64, but there should be no reason why it shouldn't work.

Note: For this an increase in the `pandoc` version from `2.11` to `2.18` was necessary, because pandoc only provided ARM version from >= `2.12`.

